### PR TITLE
Rename flatten filter to avoid conflict with Ansible 2.5 builtin

### DIFF
--- a/filter_plugins/haproxy_flatten.py
+++ b/filter_plugins/haproxy_flatten.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
 
-def flatten(d, separator='.'):
+def haproxy_flatten(d, separator='.'):
     """
     Flatten a dictionary `d` by joining nested keys with `separator`.
 
     Slightly modified from <http://codereview.stackexchange.com/a/21035>.
 
-    >>> flatten({'eggs': 'spam', 'sausage': {'eggs': 'bacon'}, 'spam': {'bacon': {'sausage': 'spam'}}})
+    >>> haproxy_flatten({'eggs': 'spam', 'sausage': {'eggs': 'bacon'}, 'spam': {'bacon': {'sausage': 'spam'}}})
     {'spam.bacon.sausage': 'spam', 'eggs': 'spam', 'sausage.eggs': 'bacon'}
     """
     def items():
         for k, v in d.items():
             try:
-                for sub_k, sub_v in flatten(v, separator).items():
+                for sub_k, sub_v in haproxy_flatten(v, separator).items():
                     yield separator.join([k, sub_k]), sub_v
             except AttributeError:
                 yield k, v
@@ -21,4 +21,4 @@ def flatten(d, separator='.'):
 
 class FilterModule(object):
     def filters(self):
-        return {'flatten': flatten}
+        return {'haproxy_flatten': haproxy_flatten}

--- a/templates/global.cfg
+++ b/templates/global.cfg
@@ -58,7 +58,7 @@ global
     ssl-default-server-ciphers {{ haproxy_global.ssl_default_server_ciphers }}
 {% endif -%}
 {% if haproxy_global.tune is defined %}
-    {% for param, value in (haproxy_global.tune | flatten).items() -%}
+    {% for param, value in (haproxy_global.tune | haproxy_flatten).items() -%}
     tune.{{ param }} {{ value }}
     {% endfor -%}
 {% endif %}


### PR DESCRIPTION
Merge PR devops-coop/ansible-haproxy#113 in our downstream repo.
Without this change, the role doesn't work at all with Ansible 2.6.

```
TASK [devops-coop.haproxy : Build up the global config] *********************************************
Tuesday 31 July 2018  09:17:37 -0400 (0:00:00.660)       0:00:38.243 **********
fatal: [47-unhaggle-prod-proxy-01]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'list object' has no attribute 'items'"}
```